### PR TITLE
Fix Done button's AccessibilityId on first appearance

### DIFF
--- a/IQKeyboardToolbar/Classes/IQBarButtonItem/IQBarButtonItemConfiguration.swift
+++ b/IQKeyboardToolbar/Classes/IQBarButtonItem/IQBarButtonItemConfiguration.swift
@@ -87,7 +87,7 @@ import UIKit
 
             newBarButtonItem.invocation = oldBarButtonItem.invocation
             newBarButtonItem.accessibilityLabel = accessibilityLabel
-            newBarButtonItem.accessibilityIdentifier = oldBarButtonItem.accessibilityLabel
+            newBarButtonItem.accessibilityIdentifier = newBarButtonItem.accessibilityLabel
             newBarButtonItem.isEnabled = oldBarButtonItem.isEnabled
             newBarButtonItem.tag = oldBarButtonItem.tag
         }


### PR DESCRIPTION
# Description

Since IQKeyboardManager 7.0 there is tiny bug. Done button's accessibilityId is not set on first appearance.
Please look at old implementation: https://github.com/hackiftekhar/IQKeyboardManager/blob/v6.5.11/IQKeyboardManagerSwift/IQToolbar/IQUIView%2BIQKeyboardToolbar.swift
There is 
`done.invocation = toolbar.doneBarButton.invocation`
 `done.accessibilityLabel = rightConfig.accessibilityLabel`
`done.accessibilityIdentifier = done.accessibilityLabel`
The accessibilityIdentifier is set from config Label.
But in new implementation in https://github.com/hackiftekhar/IQKeyboardToolbar/blob/main/IQKeyboardToolbar/Classes/IQBarButtonItem/IQBarButtonItemConfiguration.swift
`newBarButtonItem.invocation = oldBarButtonItem.invocation`
 `newBarButtonItem.accessibilityLabel = accessibilityLabel`
 `newBarButtonItem.accessibilityIdentifier = oldBarButtonItem.accessibilityLabel`
The identifier is set from old button.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
