### PR TITLE
Fix not show title bar button when text is nil

### DIFF
--- a/IQKeyboardToolbar/Classes/IQKeyboardExtension/UIView+IQKeyboardExtension.swift
+++ b/IQKeyboardToolbar/Classes/IQKeyboardExtension/UIView+IQKeyboardExtension.swift
@@ -343,7 +343,9 @@ private extension IQKeyboardExtension where Base: IQTextInputView {
 
             toolbar.titleBarButton.customView?.frame = .zero
 
-            items.append(toolbar.titleBarButton)
+            if title != nil {
+                items.append(toolbar.titleBarButton)
+            }
 
             // Flexible space
             items.append(IQBarButtonItem.flexibleBarButtonItem)


### PR DESCRIPTION
# Description
Please refer to this issue https://github.com/hackiftekhar/IQKeyboardManager/issues/2155
